### PR TITLE
Fix various renaming booboos; FAQ++

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Raptor
+# RaptorIO
 
-Lighter, faster and smarter than REX,  Raptor is the next evolutionary step in Metasploit's basic network IO functionality.
+Lighter, faster and smarter than REX,  RaptorIO is the next evolutionary step in Metasploit's basic network IO functionality.
 
 
 
 
 ## FAQ
 
-1. **What is Raptor?**  Raptor is the next generation of the core networking libraries used by Metasploit.  This includes the core Socket and Switchboard implementations as well as clients and servers for lots of protocols, both open source and proprietary.  It is intended as a general-purpose library for doing network exploitation, research, and reverse engineering, but you can also use it to power the server hosting your collection of cat GIFs.
+1. **What is RaptorIO?**  RaptorIO is the next generation of the core networking libraries used by Metasploit.  This includes the core Socket and Switchboard implementations as well as clients and servers for lots of protocols, both open source and proprietary.  It is intended as a general-purpose library for doing network exploitation, research, and reverse engineering, but you can also use it to power the server hosting your collection of cat GIFs.
 2. **Should I use it?**   Sure!  Just remember that it's not 1.0 yet and won't be for awhile.  We are open-sourcing it now because the critical early stages have been completed and we want the Ruby community to be able to have a look and help us expand it.
 3. **What are the next goals?** We want to continue building out client/server pairs for each of multiple protocols, starting with the SMB family (DCE/RPC, etc).  Goals on the horizon include a less client-centric replacement for Net::SSH as well.
-4. **I know network programming and Ruby - how can I help?**  Pull requests are welcome! Implementations of client/server pairs must be fully spec'd (ideally from the protocol's RFC) and follow the One True Rule of Raptor: "*an implementation must follow the spec by default, but allow tinkering/abuse of the protocol at every level.*"  Abstractions should be for convenience, but not lock users out of dealing with lower-level constructs.
-5. **When will Raptor be live as the networking layer in Metasploit Framework?** We hesitate to put a firm date on it, but we are working toward that goal as fast as possible.  There's lots of work to be done, and we hope you can help!
+4. **I know network programming and Ruby - how can I help?**  Pull requests are welcome! Implementations of client/server pairs must be fully spec'd (ideally from the protocol's RFC) and follow the One True Rule of RaptorIO: "*an implementation must follow the spec by default, but allow tinkering/abuse of the protocol at every level.*"  Abstractions should be for convenience, but not lock users out of dealing with lower-level constructs.
+5. **When will RaptorIO be live as the networking layer in Metasploit Framework?** We hesitate to put a firm date on it, but we are working toward that goal as fast as possible.  There's lots of work to be done, and we hope you can help!
+6. **Why RaptorIO::Socket? Why RaptorIO::Switchboard?** As the networking layer for an exploitation toolkit, RaptorIO has an an explicit design goal the ability to "pivot" new network traffic through established network connections.  The Switchboard, Socket and Comm constructs exist to  facilitate this capability.
 
 ## Installation
 
@@ -26,8 +27,8 @@ Lighter, faster and smarter than REX,  Raptor is the next evolutionary step in M
 
 ## Usage
 
-* [HTTP client and server operations](https://github.com/rapid7/raptor/wiki/HTTP-examples) with asychronous, synchronous, and manually queued interactions
-* [Arbitrary network connections](https://github.com/rapid7/raptor/wiki/Raptor-Socket-Requirements) using the Comm(connection establishment) and Switchboard(routing) abstractions.
+* [HTTP client and server operations](https://github.com/rapid7/raptor-io/wiki/HTTP-examples) with asychronous, synchronous, and manually queued interactions
+* [Arbitrary network connections](https://github.com/rapid7/raptor-io/wiki/Raptor-Socket-Requirements) using the Comm(connection establishment) and Switchboard(routing) abstractions.
 
 
 ## Immediate Goals

--- a/samples/rails_json_yaml_scanner.rb
+++ b/samples/rails_json_yaml_scanner.rb
@@ -1,17 +1,17 @@
 #!/usr/bin/env ruby
 $:.push File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'raptor'
+require 'raptor-io'
 require 'securerandom'
 
 target_uri =  ARGV[0]
 
-http_client =  Raptor::Protocol::HTTP::Client.new(switch_board: Raptor::Socket::SwitchBoard.new)
+http_client =  RaptorIO::Protocol::HTTP::Client.new(switch_board: RaptorIO::Socket::SwitchBoard.new)
 
 # Set the Content-Type to JSON
 ctype_headers = { 'Content-Type' => 'application/json' }
 
-# Benign bogus request to set a baseline for the behaviour
+# Benign bogus request to set a baseline for the behavior
 baseline_data = "{ \"#{SecureRandom.hex(rand(8)+1)}\" : \"#{SecureRandom.hex(rand(8)+1)}\" }"
 first_response = http_client.post target_uri, body: baseline_data, headers: ctype_headers, raw: true, mode: :sync
 

--- a/samples/socat.rb
+++ b/samples/socat.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 $:.push File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'raptor'
+require 'raptor-io'
 
 def usage(msg)
   $stderr.puts "ERROR: #{msg}"

--- a/samples/tomcat_mgr_login.rb
+++ b/samples/tomcat_mgr_login.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 $:.push File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'raptor'
+require 'raptor-io'
 require 'optparse'
 
 options = {}

--- a/samples/tunnel.rb
+++ b/samples/tunnel.rb
@@ -2,7 +2,7 @@
 
 $:.push File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'raptor'
+require 'raptor-io'
 require 'uri'
 
 def usage(msg = nil)
@@ -37,7 +37,7 @@ port = nil
 ARGV.each do |arg|
   begin
     arg_uri = URI.parse(arg)
-  rescue URI::InvalidURIError => e
+  rescue URI::InvalidURIError
     usage("Invalid URI (#{arg.inspect})")
   end
 


### PR DESCRIPTION
- require statements and class names in some samples
- "Raptor" -> "RaptorIO" in README
- moar FAQ
