### PR TITLE
Fix an infinite loop when parsing headers

### DIFF
--- a/lib/raptor-io/protocol/http/client.rb
+++ b/lib/raptor-io/protocol/http/client.rb
@@ -412,7 +412,7 @@ class Client
           return
         end
       else
-        # A Content-Type is not strictly necessary, the end of the response body
+        # A Content-Length is not strictly necessary, the end of the response body
         # can also be signaled by the server closing the connection. That's why
         # the following code is so ugly.
 

--- a/lib/raptor-io/protocol/http/server.rb
+++ b/lib/raptor-io/protocol/http/server.rb
@@ -243,6 +243,12 @@ class Server
 
   private
 
+  # {Socket.select Select} the server socket and all of our client sockets
+  #
+  # @return [Hash<Symbol,Socket>]
+  #   Readable sockets in :reads, Writable sockets in :writes, Errored
+  #   sockets in :errors
+  # @return [nil] If there are no changes to the selected sockets
   def select_sockets
     clock = Time.now
     sockets = Socket.select( [@server] | @sockets[:reads],

--- a/spec/raptor-io/protocol/http/server_spec.rb
+++ b/spec/raptor-io/protocol/http/server_spec.rb
@@ -232,8 +232,9 @@ describe RaptorIO::Protocol::HTTP::Server do
       end
 
       it 'sets the request timeout', speed: 'slow' do
-        server = new_server( timeout: 2 )
-        server.timeout.should == 2
+        timeout = 2
+        server = new_server( timeout: timeout )
+        server.timeout.should == timeout
         server.run_nonblock
 
         server.timeouts.should == 0
@@ -242,9 +243,13 @@ describe RaptorIO::Protocol::HTTP::Server do
         sockaddr = Socket.pack_sockaddr_in( server.port, server.address )
         socket.connect( sockaddr )
 
-        sleep 1
+        # half way through the timeout period
+        sleep(timeout / 2.0)
         server.timeouts.should == 0
-        sleep 3
+
+        # We've now slept through a total of two timeout periods, which
+        # should ensure that the client has timed out
+        sleep(timeout * 2)
         server.timeouts.should == 1
 
         socket.close

--- a/spec/raptor-io/protocol/http/server_spec.rb
+++ b/spec/raptor-io/protocol/http/server_spec.rb
@@ -226,30 +226,14 @@ describe RaptorIO::Protocol::HTTP::Server do
     end
 
     describe :timeout do
-      it 'defaults to 10', speed: 'slow' do
+      it 'defaults to 10' do
         server = new_server
         server.timeout.should == 10
-        server.run_nonblock
-
-        server.timeouts.should == 0
-
-        socket = Socket.new( Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0 )
-        sockaddr = Socket.pack_sockaddr_in( server.port, server.address )
-        socket.connect( sockaddr )
-
-        sleep 9
-
-        server.timeouts.should == 0
-
-        sleep 11
-        socket.close
-
-        server.timeouts.should == 1
       end
 
-      it 'sets the request timeout' do
-        server = new_server( timeout: 1 )
-        server.timeout.should == 1
+      it 'sets the request timeout', speed: 'slow' do
+        server = new_server( timeout: 2 )
+        server.timeout.should == 2
         server.run_nonblock
 
         server.timeouts.should == 0
@@ -258,10 +242,12 @@ describe RaptorIO::Protocol::HTTP::Server do
         sockaddr = Socket.pack_sockaddr_in( server.port, server.address )
         socket.connect( sockaddr )
 
-        sleep 2
-        socket.close
-
+        sleep 1
+        server.timeouts.should == 0
+        sleep 3
         server.timeouts.should == 1
+
+        socket.close
       end
     end
 


### PR DESCRIPTION
Verification
- [ ] set up an ssl server 

``` ruby
tcp = TCPServer.new("127.0.0.1", 1234)
ssl = OpenSSL::SSL::SSLServer.new(tcp, OpenSSL::SSL::SSLContext.new)
ssl.accept
```
- [ ] in another terminal, connect with RaptorIO::Protocol::HTTP::Client, without SSL

``` ruby
client = RaptorIO::Protocol::HTTP::Client.new( switch_board: RaptorIO::Socket::SwitchBoard.new )
client.get("http://localhost:1234", mode: :sync)
```
- [ ] See the server disconnect with an SSL error ("http request")
- [ ] BEFORE: See the client spin forever
- [ ] AFTER: raises `RaptorIO::Socket::Error::BrokenPipe` as it should
